### PR TITLE
 airflowのinstall時にegg_infoでエラーになるため、setuptoolsをupgradeする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN locale-gen
 RUN update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 RUN useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow
 
+RUN pip install --upgrade setuptools
 RUN pip install Cython pytz pyOpenSSL ndg-httpsclient pyasn1 flask_bcrypt
 #RUN pip install apache-airflow[crypto,celery,postgres,hive,hdfs,jdbc,gcp_api]==$AIRFLOW_VERSION
 RUN pip install "git+https://github.com/apache/incubator-airflow.git@${AIRFLOW_VERSION}#egg=apache-airflow[crypto,celery,postgres,hive,hdfs,jdbc,gcp_api]"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains **Dockerfile** of [apache-airflow](https://github.com/a
 
 ## Installation
 
-Pull the image from the Docker repository.
+Pull the image from the Docker repository
 
         docker pull puckel/docker-airflow
 


### PR DESCRIPTION
```
 ---> Running in 46d234fc66a9
Collecting apache-airflow[celery,crypto,gcp_api,postgres]==1.8.2
  Downloading https://files.pythonhosted.org/packages/f1/83/a5fc6da0ced7c06f080b9b423b3483a926e7a387892a9013ec12229a0a89/apache-airflow-1.8.2.tar.gz (2.3MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-3_6g48_h/apache-airflow/setup.py", line 302, in <module>
        do_setup()
      File "/tmp/pip-install-3_6g48_h/apache-airflow/setup.py", line 198, in do_setup
        check_previous()
      File "/tmp/pip-install-3_6g48_h/apache-airflow/setup.py", line 105, in check_previous
        in pip.get_installed_distributions()])
    AttributeError: module 'pip' has no attribute 'get_installed_distributions'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-3_6g48_h/apache-airflow/
The command '/bin/sh -c pip install apache-airflow[crypto,celery,postgres,gcp_api]==$AIRFLOW_VERSION' returned a non-zero code: 1
make: *** [build] Error 1
```